### PR TITLE
chore: upload coverage report only on release build

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Upload code coverage report
         uses: paambaati/codeclimate-action@v2.7.5
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

-   [ ] 🐞 Bugfix
-   [ ] ✅ Feature
-   [ ] 💅 Code style update (formatting, renaming)
-   [ ] 👮‍♂️ Refactoring (no functional changes, no api changes)
-   [x] 🛠 Build related changes
-   [ ] 📄 Documentation content changes
-   [ ] 🤔 Other (please describe):

## Description of changes

Upload coverage report only on release build

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information
N/A
